### PR TITLE
Invalid: 버튼 컴포넌트 color props 개선 및 tailwind 색상 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,24 +1,10 @@
 import React from 'react';
-import logo from './logo.svg';
-import './App.css';
+import LoginForm from './components/auth/LoginForm';
 
 function App() {
   return (
     <div className="App">
-      <header className="App-header">
-        <img src={logo} className="App-logo" alt="logo" />
-        <p>
-          Edit <code>src/App.tsx</code> and save to reload.
-        </p>
-        <a
-          className="App-link"
-          href="https://reactjs.org"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn React
-        </a>
-      </header>
+      <LoginForm />
     </div>
   );
 }

--- a/src/components/auth/EmailInput.tsx
+++ b/src/components/auth/EmailInput.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+interface EmailInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const EmailInput: React.FC<EmailInputProps> = ({ value, onChange, error }) => {
+  return (
+    <div>
+      <label>이메일</label>
+      <input
+        type="email"
+        placeholder="your@email.com"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+};
+
+export default EmailInput;

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react';
+import EmailInput from './EmailInput';
+import PasswordInput from './PasswordInput';
+import SubmitButton from './SubmitButton';
+
+const LoginForm: React.FC = () => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = () => {
+    if (!email || !password) {
+      setError('이메일과 비밀번호를 입력해주세요.');
+      return;
+    }
+
+    setError('');
+    console.log('로그인 시도:', email, password);
+    alert('로그인 요청 보냄 (콘솔 확인)');
+  };
+
+  return (
+    <div>
+      <h2>로그인</h2>
+      <EmailInput value={email} onChange={setEmail} />
+      <PasswordInput value={password} onChange={setPassword} />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <SubmitButton label="로그인" onClick={handleLogin} />
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/components/auth/PasswordInput.tsx
+++ b/src/components/auth/PasswordInput.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+
+interface PasswordInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  error?: string;
+}
+
+const PasswordInput: React.FC<PasswordInputProps> = ({ value, onChange, error }) => {
+  const [show, setShow] = useState(false);
+
+  return (
+    <div>
+      <label>비밀번호</label>
+      <input
+        type={show ? 'text' : 'password'}
+        placeholder="비밀번호"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <button type="button" onClick={() => setShow(!show)}>
+        {show ? '숨기기' : '보기'}
+      </button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </div>
+  );
+};
+
+export default PasswordInput;

--- a/src/components/auth/SubmitButton.tsx
+++ b/src/components/auth/SubmitButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+interface SubmitButtonProps {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+const SubmitButton: React.FC<SubmitButtonProps> = ({ label, onClick, disabled }) => {
+  return (
+    <button type="button" onClick={onClick} disabled={disabled}>
+      {label}
+    </button>
+  );
+};
+
+export default SubmitButton;


### PR DESCRIPTION
💡 작업 내용
버튼 컴포넌트의 color 속성을 props로 분리하여 재사용성 개선

타입 안정성을 위해 color 타입을 union type(ButtonColor)으로 명시

tailwind.config.js에 공통 색상 등록하여 일관된 스타일링 가능하도록 설정

피그마에 명시된 버튼 스타일에 맞춰 hover 및 active 상태 클래스 조건 분기

🛠 실제 적용한 예시
client/src/components/auth/Button.tsx 파일 추가

Tailwind 색상 목록:

black, white, gray, gray2, gray3, grayWhite, disabledGrayWhite, cheeseYellow, buttonGrayWhite

✅ 셀프 체크리스트
 팀장 피드백 반영 완료

 브랜치 기준 dev로 설정

 커밋 메시지 및 PR 제목 컨벤션 맞춤

 PR 전 테스트 및 시각 확인 완료