### PR TITLE
Fix: 배포 서버에서 발생하는 Docker 로그인 오류 수정

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,27 +256,27 @@ pipeline {
                                 script: "cat ${ENV_FILE}",
                                 returnStdout: true
                             ).trim()
-
+                            
+                            // Docker Registry 인증 정보도 함께 전달
                             withCredentials([usernamePassword(
                                 credentialsId: REGISTRY_CREDENTIAL_ID,
                                 usernameVariable: 'REGISTRY_USER',
                                 passwordVariable: 'REGISTRY_PASS'
                             )]) {
-                            
-                            sh """
-                                ssh -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
-                                set -e
-                                
-                                echo ">> 배포 디렉토리로 이동"
-                                cd /morphogen/neunexus/login
-                                
-                                echo ">> 이전 버전 백업"
-                                if [ -f .env.docker ]; then
-                                    cp .env.docker .env.docker.backup.\$(date +%Y%m%d%H%M%S)
-                                fi
-                                
-                                echo ">> 배포용 환경변수 파일(.env.docker) 생성"
-                                cat > .env.docker << 'ENV_EOF'
+                                sh """
+                                    ssh -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
+                                    set -e
+                                    
+                                    echo ">> 배포 디렉토리로 이동"
+                                    cd /morphogen/neunexus/login
+                                    
+                                    echo ">> 이전 버전 백업"
+                                    if [ -f .env.docker ]; then
+                                        cp .env.docker .env.docker.backup.\$(date +%Y%m%d%H%M%S)
+                                    fi
+                                    
+                                    echo ">> 배포용 환경변수 파일(.env.docker) 생성"
+                                    cat > .env.docker << 'ENV_EOF'
 ${envFileContent}
 DOCKER_REGISTRY=${DOCKER_REGISTRY}
 IMAGE_NAME=${IMAGE_NAME}
@@ -284,45 +284,45 @@ TAG=${env.IMAGE_TAG}
 LOGIN_SUBDOMAIN=${LOGIN_SUBDOMAIN}
 DEPLOY_ENV=${env.DEPLOY_ENV}
 ENV_EOF
-                                
-                                echo ">> Docker Registry 로그인"
-                                echo \${REGISTRY_PASS} | docker login ${DOCKER_REGISTRY} -u \${REGISTRY_USER} --password-stdin
-                                
-                                echo ">> 최신 버전의 Docker 이미지를 다운로드합니다: ${env.IMAGE_TAG}"
-                                docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker pull
-                                
-                                echo ">> 헬스체크를 위한 이전 컨테이너 정보 저장"
-                                OLD_CONTAINER_ID=\$(docker compose -f ${DOCKER_COMPOSE_FILE} ps -q ${IMAGE_NAME} 2>/dev/null || true)
-                                
-                                echo ">> docker-compose를 사용하여 서비스 업데이트"
-                                docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker up -d --force-recreate --no-build
-                                
-                                echo ">> 헬스체크 수행 (30초 대기)"
-                                sleep 30
-                                
-                                # 간단한 헬스체크 (실제 환경에 맞게 수정 필요)
-                                if docker compose -f ${DOCKER_COMPOSE_FILE} ps | grep -q "Up"; then
-                                    echo "✅ 배포 성공: ${env.IMAGE_TAG}"
                                     
-                                    # 이전 이미지 정리 (최근 3개 버전만 유지)
-                                    echo ">> 오래된 Docker 이미지 정리"
-                                    docker images ${DOCKER_REGISTRY}/${IMAGE_NAME} --format "{{.Tag}} {{.ID}}" | \
-                                        grep -E "^(dev|prod|docker)-[0-9]{8}" | \
-                                        sort -r | \
-                                        tail -n +4 | \
-                                        awk '{print \$2}' | \
-                                        xargs -r docker rmi || true
-                                else
-                                    echo "❌ 헬스체크 실패, 롤백을 시도합니다..."
-                                    if [ ! -z "\$OLD_CONTAINER_ID" ]; then
-                                        docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker.backup.* up -d --force-recreate --no-build
+                                    echo ">> Docker Registry 로그인 (비대화형)"
+                                    echo \${REGISTRY_PASS} | docker login ${DOCKER_REGISTRY} -u \${REGISTRY_USER} --password-stdin
+                                    
+                                    echo ">> 최신 버전의 Docker 이미지를 다운로드합니다: ${env.IMAGE_TAG}"
+                                    docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker pull
+                                    
+                                    echo ">> 헬스체크를 위한 이전 컨테이너 정보 저장"
+                                    OLD_CONTAINER_ID=\$(docker compose -f ${DOCKER_COMPOSE_FILE} ps -q ${IMAGE_NAME} 2>/dev/null || true)
+                                    
+                                    echo ">> docker-compose를 사용하여 서비스 업데이트"
+                                    docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker up -d --force-recreate --no-build
+                                    
+                                    echo ">> 헬스체크 수행 (30초 대기)"
+                                    sleep 30
+                                    
+                                    # 간단한 헬스체크 (실제 환경에 맞게 수정 필요)
+                                    if docker compose -f ${DOCKER_COMPOSE_FILE} ps | grep -q "Up"; then
+                                        echo "✅ 배포 성공: ${env.IMAGE_TAG}"
+                                        
+                                        # 이전 이미지 정리 (최근 3개 버전만 유지)
+                                        echo ">> 오래된 Docker 이미지 정리"
+                                        docker images ${DOCKER_REGISTRY}/${IMAGE_NAME} --format "{{.Tag}} {{.ID}}" | \
+                                            grep -E "^(dev|prod|docker)-[0-9]{8}" | \
+                                            sort -r | \
+                                            tail -n +4 | \
+                                            awk '{print \$2}' | \
+                                            xargs -r docker rmi || true
+                                    else
+                                        echo "❌ 헬스체크 실패, 롤백을 시도합니다..."
+                                        if [ ! -z "\$OLD_CONTAINER_ID" ]; then
+                                            docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker.backup.* up -d --force-recreate --no-build
+                                        fi
+                                        exit 1
                                     fi
-                                    exit 1
-                                fi
-                                
-                                docker logout ${DOCKER_REGISTRY}
+                                    
+                                    docker logout ${DOCKER_REGISTRY}
 EOF
-                            """
+                                """
                             }
                         }
                     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,7 +264,7 @@ pipeline {
                                 passwordVariable: 'REGISTRY_PASS'
                             )]) {
                                 sh """
-                                    ssh -t -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
+                                    ssh -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} "REGISTRY_PASS='${REGISTRY_PASS}'" "REGISTRY_USER='${REGISTRY_USER}'"<< 'EOF'
                                     set -e
                                     
                                     echo ">> 배포 디렉토리로 이동"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,7 +264,7 @@ pipeline {
                                 passwordVariable: 'REGISTRY_PASS'
                             )]) {
                                 sh """
-                                    ssh -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
+                                    ssh -t -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
                                     set -e
                                     
                                     echo ">> 배포 디렉토리로 이동"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -280,22 +280,22 @@ DEPLOY_ENV=${env.DEPLOY_ENV}
 ENV_EOF
                                 
                                 echo ">> Docker Registry 로그인"
-                                docker login ${DOCKER_REGISTRY}
+                                ${REGISTRY_PASS} | docker login ${DOCKER_REGISTRY} -u \${REGISTRY_USER} --password-stdin
                                 
                                 echo ">> 최신 버전의 Docker 이미지를 다운로드합니다: ${env.IMAGE_TAG}"
-                                docker-compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker pull
+                                docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker pull
                                 
                                 echo ">> 헬스체크를 위한 이전 컨테이너 정보 저장"
-                                OLD_CONTAINER_ID=\$(docker-compose -f ${DOCKER_COMPOSE_FILE} ps -q ${IMAGE_NAME} 2>/dev/null || true)
+                                OLD_CONTAINER_ID=\$(docker compose -f ${DOCKER_COMPOSE_FILE} ps -q ${IMAGE_NAME} 2>/dev/null || true)
                                 
                                 echo ">> docker-compose를 사용하여 서비스 업데이트"
-                                docker-compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker up -d --force-recreate --no-build
+                                docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker up -d --force-recreate --no-build
                                 
                                 echo ">> 헬스체크 수행 (30초 대기)"
                                 sleep 30
                                 
                                 # 간단한 헬스체크 (실제 환경에 맞게 수정 필요)
-                                if docker-compose -f ${DOCKER_COMPOSE_FILE} ps | grep -q "Up"; then
+                                if docker compose -f ${DOCKER_COMPOSE_FILE} ps | grep -q "Up"; then
                                     echo "✅ 배포 성공: ${env.IMAGE_TAG}"
                                     
                                     # 이전 이미지 정리 (최근 3개 버전만 유지)
@@ -309,7 +309,7 @@ ENV_EOF
                                 else
                                     echo "❌ 헬스체크 실패, 롤백을 시도합니다..."
                                     if [ ! -z "\$OLD_CONTAINER_ID" ]; then
-                                        docker-compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker.backup.* up -d --force-recreate --no-build
+                                        docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker.backup.* up -d --force-recreate --no-build
                                     fi
                                     exit 1
                                 fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -256,6 +256,12 @@ pipeline {
                                 script: "cat ${ENV_FILE}",
                                 returnStdout: true
                             ).trim()
+
+                            withCredentials([usernamePassword(
+                                credentialsId: REGISTRY_CREDENTIAL_ID,
+                                usernameVariable: 'REGISTRY_USER',
+                                passwordVariable: 'REGISTRY_PASS'
+                            )]) {
                             
                             sh """
                                 ssh -p ${DEPLOY_SERVER_PORT} -o StrictHostKeyChecking=no ${DEPLOY_SERVER_USER_HOST} << 'EOF'
@@ -317,6 +323,7 @@ ENV_EOF
                                 docker logout ${DOCKER_REGISTRY}
 EOF
                             """
+                            }
                         }
                     }
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -286,7 +286,7 @@ DEPLOY_ENV=${env.DEPLOY_ENV}
 ENV_EOF
                                 
                                 echo ">> Docker Registry 로그인"
-                                ${REGISTRY_PASS} | docker login ${DOCKER_REGISTRY} -u \${REGISTRY_USER} --password-stdin
+                                echo \${REGISTRY_PASS} | docker login ${DOCKER_REGISTRY} -u \${REGISTRY_USER} --password-stdin
                                 
                                 echo ">> 최신 버전의 Docker 이미지를 다운로드합니다: ${env.IMAGE_TAG}"
                                 docker compose -f ${DOCKER_COMPOSE_FILE} --env-file .env.docker pull


### PR DESCRIPTION
## 💡 작업 내용

- [x] Jenkins 파이프라인의 Deploy to Server 단계에서 원격 서버에 SSH로 접속하여 Docker 로그인을 시도할 때, TTY(터미널)가 없어 대화형 로그인을 수행하지 못하고 빌드가 실패하는 문제를 해결

## 💡 자세한 설명

기존 스크립트는 ssh 명령어와 heredoc('EOF') 구문을 사용하여 원격 명령을 실행했습니다. 이 방식에서는 Jenkins Credential 변수(REGISTRY_USER, REGISTRY_PASS)가 원격 서버의 셸 세션에 전달되지 않았습니다.

그 결과, 원격 서버에서 실행된 docker login 명령어는 사용자 이름과 비밀번호를 알 수 없어 대화형 프롬프트를 띄우려고 시도했고, 비대화형 환경인 Jenkins 빌드에서는 아래와 같은 오류를 내며 중단되었습니다.
```
Error: Cannot perform an interactive login from a non TTY device
```
이 문제를 해결하기 위해 ssh 명령어를 실행할 때 Jenkins의 Credential 변수를 원격 서버의 환경 변수로 직접 전달하도록 수정했습니다.

SSH 접속 시 환경 변수 전달

ssh 명령어에 "REGISTRY_USER='${REGISTRY_USER}'"와 "REGISTRY_PASS='${REGISTRY_PASS}'" 인자를 추가하여, Jenkins에 저장된 사용자 이름과 비밀번호를 원격 세션의 환경 변수로 설정합니다.

비대화형 Docker 로그인 수행

원격 서버에서 docker login을 실행할 때, 위에서 전달받은 환경 변수($REGISTRY_USER, $REGISTRY_PASS)를 사용하도록 수정했습니다.

--password-stdin 옵션을 통해 비밀번호를 안전하게 파이프로 전달하여 비대화형 로그인을 성공적으로 수행합니다.


## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
#40 Fix: Cannot perform an interactive login from a non TTY device