### PR TITLE
Fix: table component 추가

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -31,3 +31,6 @@ dist-ssr
 .DS_Store
 *storybook.log
 storybook-static
+
+#claude
+claude.md

--- a/client/src/components/mainpage/common/StatusTable.tsx
+++ b/client/src/components/mainpage/common/StatusTable.tsx
@@ -1,0 +1,84 @@
+// 타입 정의
+interface StatusTableColumn {
+  key: string;
+  label: string;
+  align?: 'left' | 'center' | 'right';
+  render?: (value: any, item: any) => React.ReactNode;
+}
+
+interface StatusTableProps {
+  columns: StatusTableColumn[];
+  data: any[];
+  height?: string;
+}
+
+export const StatusTable = ({
+  columns,
+  data,
+  height = 'h-52'
+}: StatusTableProps) => {
+  return (
+    <div
+      className={`${height} rounded border border-stroke-base-200 flex flex-col`}
+    >
+      {/* 고정 헤더 */}
+      <table className="w-full table-fixed">
+        <thead className="bg-fill-base-200">
+          <tr className="h-10">
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                className={`px-3.5 py-2 text-text-base-500 text-sm font-semibold leading-tight w-1/${columns.length} ${
+                  column.align === 'center'
+                    ? 'text-center'
+                    : column.align === 'right'
+                      ? 'text-right'
+                      : 'text-left'
+                }`}
+              >
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+      </table>
+
+      {/* 스크롤 가능한 바디 */}
+      <div className="flex-1 overflow-y-auto">
+        <table className="w-full table-fixed">
+          <tbody>
+            {data.map((item, index) => {
+              const isEven = index % 2 === 0;
+
+              return (
+                <tr
+                  key={item.id || index}
+                  className={`h-10 border-b border-stroke-base-200 ${
+                    isEven ? 'bg-fill-base-100' : 'bg-fill-alt-200'
+                  }`}
+                >
+                  {columns.map((column) => (
+                    <td
+                      key={column.key}
+                      className={`px-3.5 py-2 text-text-base-400 text-sm leading-tight w-1/${columns.length} ${
+                        column.align === 'center'
+                          ? 'text-center'
+                          : column.align === 'right'
+                            ? 'text-right'
+                            : 'text-left'
+                      } ${column.align === 'left' ? 'truncate' : ''}`}
+                    >
+                      {column.render
+                        ? column.render(item[column.key], item)
+                        : item[column.key]}
+                    </td>
+                  ))}
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};

--- a/client/src/components/mainpage/dashboard/InventoryStatus.tsx
+++ b/client/src/components/mainpage/dashboard/InventoryStatus.tsx
@@ -1,34 +1,32 @@
-import { StatusCard } from "@/components/mainpage/common/StatusCard";
-import { inventoryData } from "@/mocks/dummy/status";
-import { useNavigate } from "react-router-dom";
-import { ScrollTable } from "../common/ScrollTable";
+import { StatusCard } from '@/components/mainpage/common/StatusCard';
+import { inventoryData } from '@/mocks/dummy/status';
+import { useNavigate } from 'react-router-dom';
+import { StatusTable } from '../common/StatusTable';
 
 export const InventoryStatus = () => {
   const navigate = useNavigate();
 
+  const columns = [
+    { key: 'productCode', label: '품목코드', align: 'left' as const },
+    {
+      key: 'quantity',
+      label: '재고수량',
+      align: 'center' as const,
+      render: (value: number) => value.toLocaleString()
+    },
+    {
+      key: 'amount',
+      label: '재고금액',
+      align: 'right' as const,
+      render: (value: number) => value.toLocaleString()
+    }
+  ];
+
   return (
-    <StatusCard
-      title="재고현황"
-      onViewAll={() => navigate('/')}
-    >
-      <div className="grid grid-cols-3 gap-4 text-h6 text-text-base-500 pt-2 py-4">
-        <span>품목코드</span>
-        <span className="text-right">재고수량</span>
-        <span className="text-right">재고금액</span>
+    <StatusCard title="재고현황" onViewAll={() => navigate('/')}>
+      <div className="py-2">
+        <StatusTable columns={columns} data={inventoryData} height="h-64" />
       </div>
-      
-      <ScrollTable height="h-48">
-        {inventoryData.map((item) => (
-          <div key={item.id} className="grid grid-cols-3 gap-4 text-body-s py-2">
-            <span 
-              className="text-text-base-500">
-              {item.productCode}
-            </span>
-            <span className="text-right text-text-base-500">{item.quantity}</span>
-            <span className="text-right text-text-base-500">{item.amount.toLocaleString()}...</span>
-          </div>
-        ))}
-      </ScrollTable>
     </StatusCard>
   );
 };

--- a/client/src/components/mainpage/dashboard/SalesStatus.tsx
+++ b/client/src/components/mainpage/dashboard/SalesStatus.tsx
@@ -1,19 +1,32 @@
-import { StatusCard } from "@/components/mainpage/common/StatusCard";
-import { salesData } from "@/mocks/dummy/status";
-import { useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { ScrollTable } from "../common/ScrollTable";
+import { StatusCard } from '@/components/mainpage/common/StatusCard';
+import { salesData } from '@/mocks/dummy/status';
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { StatusTable } from '../common/StatusTable';
 
 export const SalesStatus = () => {
-  const [activeTab, setActiveTab] = useState("금일");  
-  const tabs = ["금일", "월별", "전일자"];
+  const [activeTab, setActiveTab] = useState('금일');
+  const tabs = ['금일', '월별', '전일자'];
   const navigate = useNavigate();
 
+  const columns = [
+    { key: 'productCode', label: '품목코드', align: 'left' as const },
+    {
+      key: 'quantity',
+      label: '재고수량',
+      align: 'center' as const,
+      render: (value: number) => value.toLocaleString()
+    },
+    {
+      key: 'amount',
+      label: '재고금액',
+      align: 'right' as const,
+      render: (value: number) => value.toLocaleString()
+    }
+  ];
+
   return (
-    <StatusCard
-      title="판매현황"
-      onViewAll={() => navigate('/')}
-    >
+    <StatusCard title="판매현황" onViewAll={() => navigate('/')}>
       <div className="flex space-x-2 py-4">
         {tabs.map((tab) => (
           <button
@@ -21,31 +34,17 @@ export const SalesStatus = () => {
             onClick={() => setActiveTab(tab)}
             className={`px-4 py-0.5 text-body-s border border-stroke-base-100 rounded ${
               activeTab === tab
-                ? "bg-fill-alt-200 text-primary-500"
-                : "bg-fill-base-100 text-text-base-400 hover:bg-fill-alt-200"
+                ? 'bg-fill-alt-200 text-primary-500'
+                : 'bg-fill-base-100 text-text-base-400 hover:bg-fill-alt-200'
             }`}
           >
             {tab}
           </button>
         ))}
       </div>
-  
-      <div className="space-y-2">
-        <div className="grid grid-cols-3 gap-4 text-h6 text-text-base-500 pb-2">
-          <span>품목코드</span>
-          <span className="text-right">재고수량</span>
-          <span className="text-right">재고금액</span>
-        </div>
 
-        <ScrollTable height="h-36">
-          {salesData.map((item) => (
-            <div key={item.id} className="grid grid-cols-3 gap-4 text-body-s py-2">
-              <span className="text-text-base-500">{item.productCode}</span>
-              <span className="text-right text-text-base-500">{item.quantity.toLocaleString()}</span>
-              <span className="text-right text-text-base-500">{item.amount.toLocaleString()}...</span>
-            </div>
-          ))}
-        </ScrollTable>
+      <div className="py-2">
+        <StatusTable columns={columns} data={salesData} />
       </div>
     </StatusCard>
   );


### PR DESCRIPTION
### 🎯 작업 목표
  대시보드 컴포넌트에서 반복적으로 사용되는 테이블 UI를 재사용 가능한 컴포넌트로 분리하고, 고정 헤더와 스크롤 기능을 가진 StatusTable 컴포넌트를 생성

  ### 📋 주요 변경 사항

  1. **StatusTable 컴포넌트 생성** (`src/components/mainpage/common/StatusTable.tsx`)
     - 고정 헤더와 스크롤 가능한 바디를 가진 테이블 컴포넌트
     - 유연한 컬럼 설정 지원 (정렬, 커스텀 렌더링)
     - 반응형 디자인 및 접근성 고려

  2. **기존 컴포넌트 리팩토링**
     - `SalesStatus.tsx`: StatusTable 컴포넌트 적용
     - `InventoryStatus.tsx`: 주석 처리된 기존 테이블 코드를 StatusTable로 교체

  ### 🔧 기술적 구현 사항

  - **HTML 테이블 시맨틱 사용**: `<table>`, `<thead>`, `<tbody>` 태그 활용
  - **고정 헤더 구현**: 헤더와 바디를 분리하여 헤더 고정, 바디만 스크롤
  - **반응형 컬럼 너비**: `table-fixed` 레이아웃으로 일관된 컬럼 너비 유지
  - **교대로 나타나는 행 색상**: 짝수/홀수 행에 다른 배경색 적용

 ---
📖 사용 방법

  1. 기본 사용법
  <StatusTable columns={columns} data={data} />

  2. 커스텀 렌더링 사용
// 기본 높이 (h-52)
  <StatusTable columns={columns} data={data} />

  // 커스텀 높이
  <StatusTable columns={columns} data={data} height="h-64" />
  <StatusTable columns={columns} data={data} height="h-[400px]" />


## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #이슈번호
